### PR TITLE
Fix QueueEnded event invoke

### DIFF
--- a/MediaManager/Queue/MediaQueue.cs
+++ b/MediaManager/Queue/MediaQueue.cs
@@ -18,6 +18,7 @@ namespace MediaManager.Queue
         {
             MediaItems.CollectionChanged += MediaItems_CollectionChanged;
             MediaManager.PropertyChanged += MediaManager_PropertyChanged;
+            MediaManager.MediaItemFinished += MediaManager_MediaItemFinished;
         }
 
         private int shuffleKey = int.MinValue;
@@ -116,12 +117,16 @@ namespace MediaManager.Queue
 
         internal void OnQueueChanged(object s, QueueChangedEventArgs e)
         {
-            //TODO: Queue will only end when it is bigger than 1 because with 1 it would always be at the end right away.
-            if (Current != null && Count > 1 && !HasNext)
-                OnQueueEnded(this, new QueueEndedEventArgs());
-
             QueueChanged?.Invoke(s, e);
             MediaManager?.Notification?.UpdateNotification();
+        }
+
+        private void MediaManager_MediaItemFinished(object sender, MediaItemEventArgs e)
+        {
+            if (MediaItems == null || MediaItems.Count == 0) return;
+
+            if (MediaItems.Last() == e.MediaItem)
+                OnQueueEnded(this, new QueueEndedEventArgs(e.MediaItem));
         }
 
         public int Count => MediaItems.Count;

--- a/MediaManager/Queue/QueueEndedEventArgs.cs
+++ b/MediaManager/Queue/QueueEndedEventArgs.cs
@@ -1,8 +1,13 @@
 ﻿using System;
+using MediaManager.Library;
+using MediaManager.Media;
 
 namespace MediaManager.Queue
 {
-    public class QueueEndedEventArgs : EventArgs
+    public class QueueEndedEventArgs : MediaItemEventArgs
     {
+        public QueueEndedEventArgs(IMediaItem mediaItem) : base(mediaItem)
+        {
+        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
QueueEnded event is fired before the last MediaItem

### :new: What is the new behavior (if this is a feature change)?
QueueEnded is fired after last MediaItem finishes

### :boom: Does this PR introduce a breaking change?

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [ ] Rebased onto current develop
