### PR TITLE
#634 Fix for Android Player is accessed on the wrong thread

### DIFF
--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
+using Android.OS;
 using Android.Support.V4.Media.Session;
 using Com.Google.Android.Exoplayer2;
 using Com.Google.Android.Exoplayer2.Ext.Mediasession;
@@ -332,7 +333,11 @@ namespace MediaManager.Platforms.Android.Player
 
         public override Task SeekTo(TimeSpan position)
         {
-            Player.SeekTo((long)position.TotalMilliseconds);
+            Handler mainHandler = new Handler(Looper.MainLooper);
+            mainHandler.Post(() =>
+            {
+                Player.SeekTo((long)position.TotalMilliseconds);
+            });
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
#634 Possible fix

### :arrow_heading_down: What is the current behavior?
Android player is access wrong thread

### :new: What is the new behavior (if this is a feature change)?
Android player access right thread

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
