### PR TITLE
Reset lastWindowIndex on idle state

### DIFF
--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -137,7 +137,7 @@ namespace MediaManager.Platforms.Android.Player
                 PlayerView.UseArtwork = false;
         }
 
-        protected int lastWindowIndex = 0;
+        protected int lastWindowIndex = -1;
 
         public override event BeforePlayingEventHandler BeforePlaying;
         public override event AfterPlayingEventHandler AfterPlaying;
@@ -199,6 +199,8 @@ namespace MediaManager.Platforms.Android.Player
                             //TODO: This means the whole list is finished. Should we fire an event?
                             break;
                         case Com.Google.Android.Exoplayer2.Player.StateIdle:
+                            lastWindowIndex = -1;
+                            break;
                         case Com.Google.Android.Exoplayer2.Player.StateBuffering:
                             //MediaManager.Buffered = TimeSpan.FromMilliseconds(Player.BufferedPosition);
                             break;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?
lastWindowIndex is not reset.

### :new: What is the new behavior (if this is a feature change)?
lastWindowIndex is reset when we are playing the new MediaItems.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
