### PR TITLE
Nullcheck on Current when Current Index changed

### DIFF
--- a/MediaManager/Queue/MediaQueue.cs
+++ b/MediaManager/Queue/MediaQueue.cs
@@ -107,8 +107,11 @@ namespace MediaManager.Queue
             {
                 if (SetProperty(ref _currentIndex, value))
                 {
-                    OnQueueChanged(this, new QueueChangedEventArgs(Current));
-                    MediaManager.OnMediaItemChanged(this, new MediaItemEventArgs(Current));
+                    if (Current != null)
+                    {
+                        OnQueueChanged(this, new QueueChangedEventArgs(Current));
+                        MediaManager.OnMediaItemChanged(this, new MediaItemEventArgs(Current));
+                    }
                 }
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
