### PR TITLE
Fixed TimedMetaDataChanged

### DIFF
--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -89,24 +89,19 @@ namespace MediaManager.Platforms.Apple.Player
 
         protected virtual void TimedMetaDataChanged(NSObservedChange obj)
         {
-            if (!string.IsNullOrEmpty(MediaManager.Queue.Current?.DisplayTitle) && !string.IsNullOrEmpty(MediaManager.Queue.Current?.DisplaySubtitle))
-                return;
-
             if (obj.NewValue is NSArray array && array.Count > 0)
             {
                 var avMetadataItem = array.GetItem<AVMetadataItem>(0);
                 if (avMetadataItem != null && !string.IsNullOrEmpty(avMetadataItem.StringValue))
                 {
                     var split = avMetadataItem.StringValue.Split(" - ");
-                    string displaySubtitle = split.FirstOrDefault();
-                    if (string.IsNullOrEmpty(MediaManager.Queue.Current.DisplaySubtitle))
-                        MediaManager.Queue.Current.DisplaySubtitle = displaySubtitle;
+                    string artist = split.FirstOrDefault();
+                    MediaManager.Queue.Current.Artist = artist;
 
                     if (split.Length > 1)
                     {
-                        string displayTitle = split.LastOrDefault();
-                        if (string.IsNullOrEmpty(MediaManager.Queue.Current.DisplayTitle))
-                            MediaManager.Queue.Current.DisplayTitle = displayTitle;
+                        string title = split.LastOrDefault();
+                        MediaManager.Queue.Current.Title = title;
                     }
                 }
             }

--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -89,19 +89,20 @@ namespace MediaManager.Platforms.Apple.Player
 
         protected virtual void TimedMetaDataChanged(NSObservedChange obj)
         {
+            if (MediaManager.Queue.Current == null || MediaManager.Queue.Current.IsMetadataExtracted)
+                return;
+
             if (obj.NewValue is NSArray array && array.Count > 0)
             {
                 var avMetadataItem = array.GetItem<AVMetadataItem>(0);
                 if (avMetadataItem != null && !string.IsNullOrEmpty(avMetadataItem.StringValue))
                 {
                     var split = avMetadataItem.StringValue.Split(" - ");
-                    string artist = split.FirstOrDefault();
-                    MediaManager.Queue.Current.Artist = artist;
+                    MediaManager.Queue.Current.Artist = split.FirstOrDefault();
 
                     if (split.Length > 1)
                     {
-                        string title = split.LastOrDefault();
-                        MediaManager.Queue.Current.Title = title;
+                        MediaManager.Queue.Current.Title = split.LastOrDefault();
                     }
                 }
             }


### PR DESCRIPTION
Changes:
- If the source is a stream, the metadata changes. So it have to be overwritten
- The Artist have to be set because the `DisplayTitle` is the audio stream file name like "MyStation.m3u"

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The `Artist` and `Title` not set. If you want to use `DisplayTitle` its not set correctly.

### :new: What is the new behavior (if this is a feature change)?
Artist and Title set correctly if the source is a stream (audio or video).

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Try a webradio

### :memo: Links to relevant issues/docs
#633

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
