### PR TITLE
Fixed Logic for GetFrame

### DIFF
--- a/MediaManager.FFmpegMediaMetadataRetriever/FFmpegMetadataProvider.cs
+++ b/MediaManager.FFmpegMediaMetadataRetriever/FFmpegMetadataProvider.cs
@@ -120,7 +120,7 @@ namespace MediaManager.FFmpegMediaMetadataRetriever
             {
                 var metadataRetriever = CreateMediaRetriever(mediaItem);
 
-                var bitmap = metadataRetriever.GetFrameAtTime((long)timeFromStart.TotalMilliseconds);
+                var bitmap = metadataRetriever.GetFrameAtTime((long)(timeFromStart.TotalMilliseconds * 1000));
 
                 metadataRetriever.Release();
                 return Task.FromResult(bitmap as object);

--- a/MediaManager/Platforms/Android/Media/ID3Provider.cs
+++ b/MediaManager/Platforms/Android/Media/ID3Provider.cs
@@ -133,7 +133,7 @@ namespace MediaManager.Platforms.Android.Media
             {
                 var metadataRetriever = await CreateMediaRetriever(mediaItem).ConfigureAwait(false);
 
-                image = metadataRetriever.GetFrameAtTime((long)timeFromStart.TotalMilliseconds);
+                image = metadataRetriever.GetFrameAtTime((long)(timeFromStart.TotalMilliseconds*1000));
 
                 metadataRetriever.Release();
             }

--- a/MediaManager/Platforms/Apple/Media/AVAssetProvider.cs
+++ b/MediaManager/Platforms/Apple/Media/AVAssetProvider.cs
@@ -79,7 +79,7 @@ namespace MediaManager.Platforms.Apple.Media
             var url = mediaItem.GetNSUrl();
             var imageGenerator = new AVAssetImageGenerator(AVAsset.FromUrl(url));
             imageGenerator.AppliesPreferredTrackTransform = true;
-            var cgImage = imageGenerator.CopyCGImageAtTime(new CMTime((long)timeFromStart.TotalMilliseconds, 1000000), out var actualTime, out var error);
+            var cgImage = imageGenerator.CopyCGImageAtTime(new CMTime((long)timeFromStart.TotalMilliseconds, 1000), out var actualTime, out var error);
             return Task.FromResult(cgImage as object);
         }
     }


### PR DESCRIPTION
Android - It takes Microsecond, so multiplying milliseconds with 1000
iOS, CMTime ticks in 1000's

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

### :arrow_heading_down: What is the current behavior?
GetFrame always takes initial frame since rounding logic is wrong

### :new: What is the new behavior (if this is a feature change)?
Bug Fixes Only

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
