### PR TITLE
Fix seek interval on iOS

### DIFF
--- a/MediaManager/Platforms/Apple/Notifications/NotificationManager.cs
+++ b/MediaManager/Platforms/Apple/Notifications/NotificationManager.cs
@@ -78,9 +78,11 @@ namespace MediaManager.Platforms.Apple.Notifications
                     CommandCenter.SeekForwardCommand.AddTarget(SeekForwardCommand);
 
                     CommandCenter.SkipBackwardCommand.Enabled = true;
+                    CommandCenter.SkipBackwardCommand.PreferredIntervals = new double[] { MediaManager.StepSize.TotalSeconds };
                     CommandCenter.SkipBackwardCommand.AddTarget(SkipBackwardCommand);
 
                     CommandCenter.SkipForwardCommand.Enabled = true;
+                    CommandCenter.SkipForwardCommand.PreferredIntervals = new double[] { MediaManager.StepSize.TotalSeconds };
                     CommandCenter.SkipForwardCommand.AddTarget(SkipForwardCommand);
 
                     CommandCenter.ChangeRepeatModeCommand.Enabled = true;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When you are on the notification screen, the seek interval is 10 seconds no matter what you set the seek step too.

### :new: What is the new behavior (if this is a feature change)?

If you set the seek interval to say 30, the forward and rewind seek will say 30 instead of 10

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

You must test on a real device, just start playing a track and go to the notification screen. Verify the seek step is consistent with what you set in code.

### :memo: Links to relevant issues/docs

https://developer.apple.com/documentation/mediaplayer/mpskipintervalcommand/1622899-preferredintervals

### :thinking: Checklist before submitting

- [X ] All projects build
- [X] Follows style guide lines 
- [N/A] Relevant documentation was updated
- [X] Rebased onto current develop
