### PR TITLE
Fix random crash on iOS

### DIFF
--- a/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
+++ b/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
@@ -85,6 +85,10 @@ namespace MediaManager
                 {
                     return TimeSpan.Zero;
                 }
+                if (double.IsNaN(Player.CurrentTime.Seconds) || Player.CurrentTime.IsIndefinite)
+                {
+                    return TimeSpan.Zero;
+                }
                 return TimeSpan.FromSeconds(Player.CurrentTime.Seconds);
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Audio player randomly crashes on iOS when it returns a NaN time for position

### :new: What is the new behavior (if this is a feature change)?

Player doesn't crash

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Switching between tracks quickly can produce this bug,I think it's more common on the simulator.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [N/A] Relevant documentation was updated
- [X] Rebased onto current develop
