### PR TITLE
Fixed occational crash on Android

### DIFF
--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -231,7 +231,7 @@ namespace MediaManager.Platforms.Android.Player
                 },
                 OnLoadingChangedImpl = (bool isLoading) =>
                 {
-                    if (isLoading)
+                    if (isLoading && Player.BufferedPosition >= 0)
                         MediaManager.Buffered = TimeSpan.FromMilliseconds(Player.BufferedPosition);
                 },
                 OnIsPlayingChangedImpl = (bool isPlaying) =>


### PR DESCRIPTION
Sometimes when `OnLoadingChanged` was called, `Player.BufferedPosition` would be an invalid value (very large negative number, possibly `long.MinValue`, I didn't check), which is not a valid parameter for `TimeSpan.FromMilliseconds`, and would thus cause a crash.
