### PR TITLE
Add extension to handle MPMediaItem

### DIFF
--- a/MediaManager/Platforms/Ios/Media/MPMediaItemExtensions.cs
+++ b/MediaManager/Platforms/Ios/Media/MPMediaItemExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CoreGraphics;
+using MediaManager.Library;
+using MediaPlayer;
+
+namespace MediaManager.Platforms.Ios.Media
+{
+    public static class MPMediaItemExtensions
+    {
+        public static IMediaItem ToMediaItem(this MPMediaItem item)
+        {
+            var output = new MediaItem
+            {
+                MediaType = MediaType.Audio,
+                Album = item.AlbumTitle,
+                Artist = item.Artist,
+                Compilation = null,
+                Composer = item.Composer,
+                Duration = TimeSpan.FromSeconds(item.PlaybackDuration),
+                Genre = item.Genre,
+                Title = item.Title,
+                AlbumArtist = item.AlbumArtist,
+                DiscNumber = item.DiscNumber,
+                MediaUri = item.AssetURL.ToString(),
+                NumTracks = item.AlbumTrackCount,
+                UserRating = item.Rating,
+                Id = item.PersistentID.ToString()
+            };
+            
+            if (item.ReleaseDate != null)
+                output.Date = (DateTime)item.ReleaseDate;
+            
+            if (item.Artwork != null)
+                output.Image = item.Artwork.ImageWithSize(new CGSize(300, 300));
+            
+            if (output.Date != null)
+                output.Year = output.Date.Year;
+            
+            return output;
+        }
+        
+        public static IEnumerable<IMediaItem> ToMediaItems(this IEnumerable<MPMediaItem> items)
+        {
+            return items
+                .Where(i => i.AssetURL != null && i.IsCloudItem == false && i.HasProtectedAsset == false)
+                .Select(i => i.ToMediaItem());
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Does not convert MPMediaItems to MediaItems

### :new: What is the new behavior (if this is a feature change)?

Extension methods added to convert MPMediaItems to MediaItems the player understands.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Perform a MPMediaQuery and try to play the audio.

```
var musicQuery = MPMediaQuery.SongsQuery;
musicQuery.GroupingType = MPMediaGrouping.Title;

var songs = musicQuery.Items.ToMediaItems();
```

I'm not sure if this is really the correct place to add this. But I figured it would be better to just get something in so that we can discuss if changes are necessary.

### :memo: Links to relevant issues/docs

#746

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
