### PR TITLE
improved handling for playback position changes in iOS control center

### DIFF
--- a/MediaManager/MediaManagerBase.cs
+++ b/MediaManager/MediaManagerBase.cs
@@ -393,7 +393,12 @@ namespace MediaManager
         }
 
         internal void OnMediaItemFinished(object sender, MediaItemEventArgs e) => MediaItemFinished?.Invoke(sender, e);
-        internal void OnPositionChanged(object sender, PositionChangedEventArgs e) => PositionChanged?.Invoke(sender, e);
+
+        internal void OnPositionChanged(object sender, PositionChangedEventArgs e)
+        {
+            PositionChanged?.Invoke(sender, e);
+            Notification?.UpdateNotification();
+        }
 
         internal void OnStateChanged(object sender, StateChangedEventArgs e)
         {

--- a/MediaManager/Platforms/Apple/Notifications/NotificationManager.cs
+++ b/MediaManager/Platforms/Apple/Notifications/NotificationManager.cs
@@ -1,4 +1,5 @@
-﻿using MediaManager.Notifications;
+﻿using System;
+using MediaManager.Notifications;
 using MediaPlayer;
 
 namespace MediaManager.Platforms.Apple.Notifications
@@ -90,6 +91,9 @@ namespace MediaManager.Platforms.Apple.Notifications
 
                     CommandCenter.ChangeShuffleModeCommand.Enabled = true;
                     CommandCenter.ChangeShuffleModeCommand.AddTarget(ShuffleCommand);
+
+                    CommandCenter.ChangePlaybackPositionCommand.Enabled = true;
+                    CommandCenter.ChangePlaybackPositionCommand.AddTarget(PlaybackPositionCommand);
                 }
                 else
                 {
@@ -108,6 +112,8 @@ namespace MediaManager.Platforms.Apple.Notifications
                     CommandCenter.ChangeRepeatModeCommand.Enabled = false;
 
                     CommandCenter.ChangeShuffleModeCommand.Enabled = false;
+
+                    CommandCenter.ChangePlaybackPositionCommand.Enabled = false;
                 }
             }
         }
@@ -181,12 +187,14 @@ namespace MediaManager.Platforms.Apple.Notifications
         protected virtual MPRemoteCommandHandlerStatus SeekForwardCommand(MPRemoteCommandEvent arg)
         {
             MediaManager.StepForward();
+            UpdateNotification();
             return MPRemoteCommandHandlerStatus.Success;
         }
 
         protected virtual MPRemoteCommandHandlerStatus SeekBackwardCommand(MPRemoteCommandEvent arg)
         {
             MediaManager.StepBackward();
+            UpdateNotification();
             return MPRemoteCommandHandlerStatus.Success;
         }
 
@@ -211,6 +219,19 @@ namespace MediaManager.Platforms.Apple.Notifications
         protected virtual MPRemoteCommandHandlerStatus ShuffleCommand(MPRemoteCommandEvent arg)
         {
             MediaManager.ToggleShuffle();
+            return MPRemoteCommandHandlerStatus.Success;
+        }
+
+        protected virtual MPRemoteCommandHandlerStatus PlaybackPositionCommand(MPRemoteCommandEvent arg)
+        {
+            if (!(arg is MPChangePlaybackPositionCommandEvent e))
+            {
+                return MPRemoteCommandHandlerStatus.CommandFailed;
+            }
+
+            MediaManager.SeekTo(TimeSpan.FromSeconds(e.PositionTime));
+
+            UpdateNotification();
             return MPRemoteCommandHandlerStatus.Success;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This pull request fixes playback position in the iOS control center, which previously did not update in response to the skip forward and backward commands. As part of this change, I've also enabled the direct control of playback position in the iOS notification.

### :arrow_heading_down: What is the current behavior?
Currently, this library does not update the notification when the user presses the seek buttons in the iOS notification (found in Control Center) for currently playing audio.

### :new: What is the new behavior (if this is a feature change)?
The position indicator in the notification updates in response to pressing the seek buttons, and allows direct manipulation of the current playback position with the slider.

### :boom: Does this PR introduce a breaking change?
Nope.

### :bug: Recommendations for testing
This only impacts iOS, and can be verified by playing any media.
