### PR TITLE
Bugfix Starts the timer again on calling Init()

### DIFF
--- a/MediaManager/IMediaManager.cs
+++ b/MediaManager/IMediaManager.cs
@@ -38,6 +38,7 @@ namespace MediaManager
         IMediaQueue Queue { get; set; }
 
         void Init();
+        void InitTimer();
 
         /// <summary>
         /// Plays a media item

--- a/MediaManager/MediaManagerBase.cs
+++ b/MediaManager/MediaManagerBase.cs
@@ -83,12 +83,15 @@ namespace MediaManager
         public virtual void Init()
         {
             IsInitialized = true;
-            InitTimer();
         }
 
-        private void InitTimer()
+        public void InitTimer()
         {
-            Timer.AutoReset = true;
+            Timer = new Timer(TimerInterval)
+            {
+                AutoReset = true,
+                Enabled = true
+            };
             Timer.Elapsed += Timer_Elapsed;
             Timer.Start();
         }

--- a/MediaManager/MediaManagerBase.cs
+++ b/MediaManager/MediaManagerBase.cs
@@ -19,9 +19,7 @@ namespace MediaManager
     {
         public MediaManagerBase()
         {
-            Timer.AutoReset = true;
-            Timer.Elapsed += Timer_Elapsed;
-            Timer.Start();
+            InitTimer();
         }
 
         private bool _isInitialized = true;
@@ -85,6 +83,14 @@ namespace MediaManager
         public virtual void Init()
         {
             IsInitialized = true;
+            InitTimer();
+        }
+
+        private void InitTimer()
+        {
+            Timer.AutoReset = true;
+            Timer.Elapsed += Timer_Elapsed;
+            Timer.Start();
         }
 
         public abstract IMediaPlayer MediaPlayer { get; set; }

--- a/MediaManager/MediaManagerBase.cs
+++ b/MediaManager/MediaManagerBase.cs
@@ -87,6 +87,11 @@ namespace MediaManager
 
         public void InitTimer()
         {
+            if (Timer?.Enabled == true)
+            {
+                return;
+            }
+
             Timer = new Timer(TimerInterval)
             {
                 AutoReset = true,

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ protected override void OnNewIntent(Intent intent)
 
 ### Disposing
 
-The player can be disposed via `CrossMediaManager.Current.Dispose()`. Make sure to call `CrossMediaManager.Current.Init()` if you used dispose before opening another video.
+The player can be disposed via `CrossMediaManager.Current.Dispose()`. Make sure to call `CrossMediaManager.Current.InitTimer()` if you used dispose before opening another video.
 
 ### Play a single media item
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ protected override void OnNewIntent(Intent intent)
 }
 ```
 
+### Disposing
+
+The player can be disposed via `CrossMediaManager.Current.Dispose()`. Make sure to call `CrossMediaManager.Current.Init()` if you used dispose before opening another video.
+
 ### Play a single media item
 
 ```csharp


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR fixes a bug that comes up, when disposing the mediamanager. 

### :arrow_heading_down: What is the current behavior?

The current behavior is as follows: If I call dispose on the mediaManager, the timer will be stopped and never subscribed to again. For example, I open a video, close the page, call `CrossMediaManager.Current.Dispose()` . Open another video, with calling `CrossMediaManager.Current.Init()`. Now on opening the second video no events are fired from the timer.

### :new: What is the new behavior (if this is a feature change)?

The timer starts firing events again after `CrossMediaManager.Current.Init()` was called.

### :boom: Does this PR introduce a breaking change?

Should not break anything.

### :bug: Recommendations for testing

Opening multiple videos on different pages, calling dispose every time a page is closed.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
