### PR TITLE
When media player state is StateError, return Failed state instead of Stopped.

### DIFF
--- a/MediaManager/Platforms/Android/Playback/PlaybackStateExtensions.cs
+++ b/MediaManager/Platforms/Android/Playback/PlaybackStateExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Android.Support.V4.Media.Session;
+﻿using System;
+using Android.Support.V4.Media.Session;
 using MediaManager.Player;
 
 namespace MediaManager.Platforms.Android.Playback
@@ -31,6 +32,7 @@ namespace MediaManager.Platforms.Android.Playback
 
                 case PlaybackStateCompat.StateNone:
                 case PlaybackStateCompat.StateError:
+                    return MediaPlayerState.Failed;
                 case PlaybackStateCompat.StateStopped:
                     return MediaPlayerState.Stopped;
 

--- a/MediaManager/Platforms/Android/Playback/PlaybackStateExtensions.cs
+++ b/MediaManager/Platforms/Android/Playback/PlaybackStateExtensions.cs
@@ -31,10 +31,11 @@ namespace MediaManager.Platforms.Android.Playback
                     return MediaPlayerState.Buffering;
 
                 case PlaybackStateCompat.StateNone:
-                case PlaybackStateCompat.StateError:
-                    return MediaPlayerState.Failed;
                 case PlaybackStateCompat.StateStopped:
                     return MediaPlayerState.Stopped;
+
+                case PlaybackStateCompat.StateError:
+                    return MediaPlayerState.Failed;
 
                 default:
                     return MediaPlayerState.Stopped;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
When the player stops because of a network error, MediaManager returns the state Stopped.

### :new: What is the new behavior (if this is a feature change)?
When the player stops due to a network error or another error, return the state failed.
If a user of the library wants to handle retries on his own, is important to understand if the player stopped because there was a failure or not. 

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
