### PR TITLE
Fix DisplayImage metadata for iOS

### DIFF
--- a/MediaManager/Platforms/Ios/Media/AVAssetImageProvider.cs
+++ b/MediaManager/Platforms/Ios/Media/AVAssetImageProvider.cs
@@ -24,9 +24,9 @@ namespace MediaManager.Platforms.Ios.Media
                 {
                     var location = MediaManager.Extractor.GetMediaLocation(mediaItem.DisplayImageUri);
                     if (location == MediaLocation.Resource)
-                        mediaItem.Image = image = UIImage.FromBundle(mediaItem.DisplayImageUri);
+                        mediaItem.DisplayImage = image = UIImage.FromBundle(mediaItem.DisplayImageUri);
                     else
-                        mediaItem.Image = image = UIImage.LoadFromData(NSData.FromUrl(new NSUrl(mediaItem.DisplayImageUri)));
+                        mediaItem.DisplayImage = image = UIImage.LoadFromData(NSData.FromUrl(new NSUrl(mediaItem.DisplayImageUri)));
                 }
                 if (image == null && !string.IsNullOrEmpty(mediaItem.AlbumImageUri))
                 {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The Display Image for iOS is not set correctly

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing
- Set the DisplayImageUri field of the metadata to a Uri 
- Set the DisplayImageUri of the metadata to a local file.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
