### PR TITLE
A IsFullWindow new property has been added and implemented for UWP

### DIFF
--- a/MediaManager.Forms/VideoView.cs
+++ b/MediaManager.Forms/VideoView.cs
@@ -47,6 +47,9 @@ namespace MediaManager.Forms
                 case nameof(MediaPlayer.VideoPlaceholder):
                     if (MediaPlayer.VideoPlaceholder is ImageSource imageSource)
                         VideoPlaceholder = imageSource;
+                    break;           
+                case nameof(MediaPlayer.IsFullWindow):
+                        IsFullWindow = MediaPlayer.IsFullWindow;
                     break;
                 default:
                     break;
@@ -150,7 +153,10 @@ namespace MediaManager.Forms
             BindableProperty.Create(nameof(Speed), typeof(float), typeof(VideoView), 1.0f, propertyChanged: OnSpeedPropertyChanged, defaultValueCreator: x => MediaManager.Speed);
 
         public static readonly BindableProperty VideoPlaceholderProperty =
-            BindableProperty.Create(nameof(VideoPlaceholder), typeof(ImageSource), typeof(VideoView), null, propertyChanged: OnVideoPlaceholderPropertyChanged, defaultValueCreator: x => MediaManager.MediaPlayer.VideoPlaceholder?.ToImageSource());
+            BindableProperty.Create(nameof(VideoPlaceholder), typeof(ImageSource), typeof(VideoView), null, propertyChanged: OnVideoPlaceholderPropertyChanged, defaultValueCreator: x => MediaManager.MediaPlayer.VideoPlaceholder?.ToImageSource());              
+        
+        public static readonly BindableProperty IsFullWindowProperty =
+            BindableProperty.Create(nameof(IsFullWindow), typeof(bool), typeof(VideoView), false, propertyChanged: OnIsFullWindowPropertyChanged, defaultValueCreator: x => MediaManager.MediaPlayer.IsFullWindow);
 
         public VideoAspectMode VideoAspect
         {
@@ -246,6 +252,12 @@ namespace MediaManager.Forms
         {
             get { return (ImageSource)GetValue(VideoPlaceholderProperty); }
             set { SetValue(VideoPlaceholderProperty, value); }
+        }        
+        
+        public bool IsFullWindow
+        {
+            get { return (bool)GetValue(IsFullWindowProperty); }
+            set { SetValue(IsFullWindowProperty, value); }
         }
 
         private static async void OnSourcePropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -299,6 +311,11 @@ namespace MediaManager.Forms
             if (newValue is Xamarin.Forms.ImageSource imageSource)
                 MediaManager.MediaPlayer.VideoPlaceholder = await imageSource.ToNative().ConfigureAwait(false);
 #endif
+        }
+
+        private static void OnIsFullWindowPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            MediaManager.MediaPlayer.IsFullWindow = (bool)newValue;
         }
 
         public virtual void Dispose()

--- a/MediaManager.Forms/VideoView.cs
+++ b/MediaManager.Forms/VideoView.cs
@@ -65,6 +65,9 @@ namespace MediaManager.Forms
                     break;
                 case nameof(MediaManager.AutoPlay):
                     AutoPlay = MediaManager.AutoPlay;
+                    break;                
+                case nameof(MediaManager.IsFullWindow):
+                    IsFullWindow = MediaManager.IsFullWindow;
                     break;
                 case nameof(MediaManager.RepeatMode):
                     Repeat = MediaManager.RepeatMode;
@@ -316,7 +319,7 @@ namespace MediaManager.Forms
         private static void OnIsFullWindowPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             MediaManager.MediaPlayer.IsFullWindow = (bool)newValue;
-        }
+        }        
 
         public virtual void Dispose()
         {

--- a/MediaManager/MediaManagerBase.cs
+++ b/MediaManager/MediaManagerBase.cs
@@ -160,6 +160,13 @@ namespace MediaManager
         {
             get => _autoPlay;
             set => SetProperty(ref _autoPlay, value);
+        }        
+        
+        private bool _isFullWindow = false;
+        public bool IsFullWindow
+        {
+            get => _isFullWindow;
+            set => SetProperty(ref _isFullWindow, value);
         }
 
         private bool _retryPlayOnFailed = true;

--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -136,6 +136,14 @@ namespace MediaManager.Platforms.Android.Player
                 PlayerView.UseArtwork = false;
         }
 
+        public override void UpdateIsFullWindow(bool isFullWindow)
+        {
+            if (PlayerView == null)
+                return;
+
+            //TODO: Implement isFullWindow
+        }
+
         protected int lastWindowIndex = -1;
 
         protected virtual void Initialize()

--- a/MediaManager/Platforms/Ios/Player/IosMediaPlayer.cs
+++ b/MediaManager/Platforms/Ios/Player/IosMediaPlayer.cs
@@ -86,6 +86,14 @@ namespace MediaManager.Platforms.Ios.Player
             }
         }
 
+        public override void UpdateIsFullWindow(bool isFullWindow)
+        {
+            if (PlayerView == null)
+                return;
+
+            //TODO: Implement isFullWindow
+        }
+
         protected override void Initialize()
         {
             base.Initialize();

--- a/MediaManager/Platforms/Mac/Player/MacMediaPlayer.cs
+++ b/MediaManager/Platforms/Mac/Player/MacMediaPlayer.cs
@@ -66,5 +66,13 @@ namespace MediaManager.Platforms.Mac.Player
 
             //TODO: Implement placeholder
         }
+
+        public override void UpdateIsFullWindow(bool isFullWindow)
+        {
+            if (PlayerView == null)
+                return;
+
+            //TODO: Implement isFullWindow
+        }
     }
 }

--- a/MediaManager/Platforms/Tizen/Player/TizenMediaPlayer.cs
+++ b/MediaManager/Platforms/Tizen/Player/TizenMediaPlayer.cs
@@ -55,6 +55,14 @@ namespace MediaManager.Platforms.Tizen.Player
             //TODO: Implement placeholder
         }
 
+        public override void UpdateIsFullWindow(bool isFullWindow)
+        {
+            if (PlayerView == null)
+                return;
+
+            //TODO: Implement isFullWindow
+        }
+
         public virtual void Initialize()
         {
             Player = new TizenPlayer();

--- a/MediaManager/Platforms/Uap/Player/WindowsMediaPlayer.cs
+++ b/MediaManager/Platforms/Uap/Player/WindowsMediaPlayer.cs
@@ -103,6 +103,14 @@ namespace MediaManager.Platforms.Uap.Player
                 PlayerView.PlayerView.PosterSource = imageSource;
         }
 
+        public override void UpdateIsFullWindow(bool isFullWindow)
+        {
+            if (PlayerView == null)
+                return;
+
+            PlayerView.PlayerView.IsFullWindow = isFullWindow;
+        }
+
         public virtual void Initialize()
         {
             Player = new MediaPlayer();

--- a/MediaManager/Platforms/Wpf/Player/WpfMediaPlayer.cs
+++ b/MediaManager/Platforms/Wpf/Player/WpfMediaPlayer.cs
@@ -83,6 +83,14 @@ namespace MediaManager.Platforms.Wpf.Player
             //TODO: Implement placeholder
         }
 
+        public override void UpdateIsFullWindow(bool isFullWindow)
+        {
+            if (PlayerView == null)
+                return;
+
+            //TODO: Implement isFullWindow
+        }
+
         public virtual void Initialize()
         {
             Application.Current.Dispatcher.Invoke((Action)delegate

--- a/MediaManager/Playback/IPlaybackManager.cs
+++ b/MediaManager/Playback/IPlaybackManager.cs
@@ -70,6 +70,11 @@ namespace MediaManager.Playback
         bool AutoPlay { get; set; }
 
         /// <summary>
+        /// Indicates if the Player is in full screen
+        /// </summary>
+        bool IsFullWindow { get; set; }
+
+        /// <summary>
         /// Will keep the screen on when set to true and a VideoView is on the screen and playing
         /// </summary>
         bool KeepScreenOn { get; set; }

--- a/MediaManager/Player/IMediaPlayer.cs
+++ b/MediaManager/Player/IMediaPlayer.cs
@@ -45,6 +45,8 @@ namespace MediaManager.Player
 
         object VideoPlaceholder { get; set; }
 
+        bool IsFullWindow { get; set; }
+
         /// <summary>
         /// Starts playing the MediaItem
         /// </summary>

--- a/MediaManager/Player/MediaPlayerBase.cs
+++ b/MediaManager/Player/MediaPlayerBase.cs
@@ -21,6 +21,7 @@ namespace MediaManager.Player
             UpdateVideoAspect(VideoAspect);
             UpdateShowPlaybackControls(ShowPlaybackControls);
             UpdateVideoPlaceholder(VideoPlaceholder);
+            UpdateIsFullWindow(IsFullWindow);
         }
 
         protected VideoAspectMode _videoAspect;
@@ -77,7 +78,20 @@ namespace MediaManager.Player
             }
         }
 
+        private bool _isFullWindow;
+        public virtual bool IsFullWindow
+        {
+            get => _isFullWindow;
+            set
+            {
+                if (SetProperty(ref _isFullWindow, value))
+                    UpdateIsFullWindow(value);
+            }
+        }
+
         public abstract void UpdateVideoPlaceholder(object value);
+
+        public abstract void UpdateIsFullWindow(bool value);
 
         public event BeforePlayingEventHandler BeforePlaying;
         public event AfterPlayingEventHandler AfterPlaying;

--- a/Samples/ElementPlayer.Forms.UI/Pages/PlayerPage.xaml
+++ b/Samples/ElementPlayer.Forms.UI/Pages/PlayerPage.xaml
@@ -5,13 +5,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:viewModels="clr-namespace:ElementPlayer.Core.ViewModels;assembly=ElementPlayer.Core"
     xmlns:mm="clr-namespace:MediaManager.Forms;assembly=MediaManager.Forms"
-    x:Class="ElementPlayer.Forms.UI.Pages.PlayerPage" 
+    x:Class="ElementPlayer.Forms.UI.Pages.PlayerPage"
     x:TypeArguments="viewModels:PlayerViewModel">
     <ContentPage.Content>
         <StackLayout Orientation="Vertical">
             <Button Text="Browse" Command="{Binding BrowseCommand}" />
             <Image Source="{Binding Image}" HorizontalOptions="FillAndExpand" HeightRequest="200" />
-            <mm:VideoView BackgroundColor="Red" VerticalOptions="FillAndExpand" VideoAspect="AspectFit" ShowControls="True" VideoPlaceholder="xamarin_logo.png" />
+            <mm:VideoView BackgroundColor="Red" VerticalOptions="FillAndExpand" VideoAspect="AspectFit" ShowControls="True" VideoPlaceholder="xamarin_logo.png" IsFullWindow="True" />
         </StackLayout>
     </ContentPage.Content>
 </mvx:MvxContentPage>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
I have added the IsFullWindow property so that the VideoView control can pass a video to full screen when the native video controls are hidden.

### :arrow_heading_down: What is the current behavior?
There is no way to put a video in full screen if you have the native video controls hidden.

### :new: What is the new behavior (if this is a feature change)?
Now the VideoView control has an IsFullWindow property to add the video to full screen. (only for UWP)

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
No.

### :memo: Links to relevant issues/docs
No.

### :thinking: Checklist before submitting

- [Yes ] All projects build
- [Yes ] Follows style guide lines 
- [Yes] Rebased onto current develop
