### PR TITLE
Add fallback delegate to QueueNavigator that allows to provide the media item when it can't be found.

### DIFF
--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -43,7 +43,7 @@ namespace MediaManager.Platforms.Android.Player
         protected DefaultTrackSelector TrackSelector { get; set; }
 
         protected MediaSessionConnector MediaSessionConnector { get; set; }
-        protected QueueNavigator QueueNavigator { get; set; }
+        public QueueNavigator QueueNavigator { get; protected set; }
         protected ConcatenatingMediaSource MediaSource { get; set; }
         protected QueueDataAdapter QueueDataAdapter { get; set; }
         protected QueueMediaSourceFactory MediaSourceFactory { get; set; }

--- a/MediaManager/Platforms/Android/Queue/QueueNavigator.cs
+++ b/MediaManager/Platforms/Android/Queue/QueueNavigator.cs
@@ -5,6 +5,7 @@ using Android.Support.V4.Media;
 using Android.Support.V4.Media.Session;
 using Com.Google.Android.Exoplayer2;
 using Com.Google.Android.Exoplayer2.Ext.Mediasession;
+using MediaManager.Library;
 using MediaManager.Platforms.Android.Media;
 
 namespace MediaManager.Platforms.Android.Queue
@@ -13,6 +14,8 @@ namespace MediaManager.Platforms.Android.Queue
     {
         protected MediaSessionCompat MediaSession { get; }
         protected MediaManagerImplementation MediaManager => CrossMediaManager.Android;
+
+        public Func<IPlayer, int, IMediaItem> MediaDescriptionRetriever { get; set; }
 
         public QueueNavigator(MediaSessionCompat mediaSession) : base(mediaSession)
         {
@@ -30,7 +33,12 @@ namespace MediaManager.Platforms.Android.Queue
 
         public override MediaDescriptionCompat GetMediaDescription(IPlayer player, int windowIndex)
         {
-            return MediaManager.Queue.ElementAtOrDefault(windowIndex)?.ToMediaDescription();
+            var mediaItem = MediaManager.Queue.ElementAtOrDefault(windowIndex);
+            if(mediaItem == null && MediaDescriptionRetriever != null)
+            {
+                mediaItem = MediaDescriptionRetriever.Invoke(player, windowIndex);
+            }
+            return mediaItem?.ToMediaDescription();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Workaround for bug

### :arrow_heading_down: What is the current behavior?
The app crashes when the media item is null

### :new: What is the new behavior (if this is a feature change)?
The delegate is being called, that can provide a media item

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See #753 

### :memo: Links to relevant issues/docs
See #753 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
