### PR TITLE
Fix/814 ns internal inconsistency exception

### DIFF
--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -227,7 +227,9 @@ namespace MediaManager.Platforms.Apple.Player
         public virtual async Task Play(AVPlayerItem playerItem)
         {
             Player.ActionAtItemEnd = AVPlayerActionAtItemEnd.None;
-            Player.ReplaceCurrentItemWithPlayerItem(playerItem);
+            //Player.ReplaceCurrentItemWithPlayerItem(playerItem);
+            Player.RemoveAllItems();
+            Player.InsertItem(playerItem, null);
             await Play();
         }
 

--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -227,7 +227,6 @@ namespace MediaManager.Platforms.Apple.Player
         public virtual async Task Play(AVPlayerItem playerItem)
         {
             Player.ActionAtItemEnd = AVPlayerActionAtItemEnd.None;
-            //Player.ReplaceCurrentItemWithPlayerItem(playerItem);
             Player.RemoveAllItems();
             Player.InsertItem(playerItem, null);
             await Play();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

SIGABRT: Objective-C exception thrown. Name: NSInternalInconsistencyException Reason: Cannot remove an observer <NSKeyValueObservance 0x281ff9440> for the key path "currentItem.status" from <AVQueuePlayer 0x281647980>, most likely because the value for the key "currentItem" has changed without an appropriate KVO notification being sent.

### :new: What is the new behavior (if this is a feature change)?

No crash

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Try iOS Playback

### :memo: Links to relevant issues/docs

https://github.com/Baseflow/XamarinMediaManager/issues/814

### :thinking: Checklist before submitting

- [ x] All projects build
- [ x] Follows style guide lines 
- [ x] Relevant documentation was updated
- [ ] Rebased onto current develop
