### PR TITLE
Enabled setting auto exit full screen when playback completes on iOS …

### DIFF
--- a/MediaManager.Forms/Platforms/Android/VideoViewRenderer.cs
+++ b/MediaManager.Forms/Platforms/Android/VideoViewRenderer.cs
@@ -22,6 +22,7 @@ namespace MediaManager.Forms.Platforms.Android
             {
                 args.OldElement.Dispose();
             }
+
             if (args.NewElement != null)
             {
                 if (Control == null)

--- a/MediaManager.Forms/Platforms/Ios/VideoViewRenderer.cs
+++ b/MediaManager.Forms/Platforms/Ios/VideoViewRenderer.cs
@@ -16,6 +16,7 @@ namespace MediaManager.Forms.Platforms.iOS
             {
                 args.OldElement.Dispose();
             }
+
             if (args.NewElement != null)
             {
                 if (Control == null)
@@ -24,6 +25,8 @@ namespace MediaManager.Forms.Platforms.iOS
                     _videoView = new MediaManager.Platforms.Ios.Video.VideoView();
                     SetNativeControl(_videoView);
                 }
+
+                Control.PlayerViewController.ExitsFullScreenWhenPlaybackEnds = args.NewElement.ExitsFullScreenWhenPlaybackEnds;
             }
 
             base.OnElementChanged(args);

--- a/MediaManager.Forms/VideoView.cs
+++ b/MediaManager.Forms/VideoView.cs
@@ -110,6 +110,8 @@ namespace MediaManager.Forms
             Buffered = e.Buffered;
         }
 
+        public bool ExitsFullScreenWhenPlaybackEnds { get; set; }
+
         public static readonly BindableProperty VideoAspectProperty =
             BindableProperty.Create(nameof(VideoAspect), typeof(VideoAspectMode), typeof(VideoView), VideoAspectMode.AspectFit, propertyChanged: OnVideoAspectPropertyChanged, defaultValueCreator: x => MediaManager.MediaPlayer.VideoAspect);
 


### PR DESCRIPTION
…cannot find equal functionality on Android in order to implement.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

When video playback on iOS is in full screen mode and the media item completes, the view is auto switched to normal inline view. Without closing full screen first any navigation will fail to actually navigate

### :arrow_heading_down: What is the current behavior?

Full screen prevents navigation

### :new: What is the new behavior (if this is a feature change)?

Full screen closes at the end of the media item.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Try setting the value in XAML on VideoView and play full screen video with the MediaItemComplete event handler performing a navigation.

### :memo: Links to relevant issues/docs

n/a

### :thinking: Checklist before submitting

- [x ] All projects build
- [ x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
