### PR TITLE
Avoid creating an NSError

### DIFF
--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -166,9 +166,22 @@ namespace MediaManager.Platforms.Apple.Player
 
         protected virtual void DidErrorOcurred(NSNotification obj)
         {
-            //TODO: Error should not be null after this or it will crash.
-            var error = Player?.CurrentItem?.Error ?? new NSError();
-            MediaManager.OnMediaItemFailed(this, new MediaItemFailedEventArgs(MediaManager.Queue?.Current, new NSErrorException(error), error?.LocalizedDescription));
+            Exception exception = null;
+            string message = null;
+            
+            var error = Player?.CurrentItem?.Error;
+            if(error != null)
+            {
+                exception = new NSErrorException(error);
+                message = error.LocalizedDescription;
+            }
+            else
+            {
+                message = obj?.ToString() ?? "MediaItem failed with unknown reason";
+                exception = new ApplicationException(message);
+            }            
+
+            MediaManager.OnMediaItemFailed(this, new MediaItemFailedEventArgs(MediaManager.Queue?.Current, exception, message));
         }
 
         protected virtual async void DidFinishPlaying(NSNotification obj)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix #841 

### :arrow_heading_down: What is the current behavior?
Creating a new NSError

### :new: What is the new behavior (if this is a feature change)?
Throw an ApplicationException

### :boom: Does this PR introduce a breaking change?
Jup, an ApplicationException is passed as an argument.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
