### PR TITLE
Add flag immutable for intent

### DIFF
--- a/MediaManager/Platforms/Android/MediaManagerImplementation.cs
+++ b/MediaManager/Platforms/Android/MediaManagerImplementation.cs
@@ -92,7 +92,11 @@ namespace MediaManager
                 sessionIntent = new Intent(Context, activity.GetType());
             else
                 sessionIntent = Context.PackageManager.GetLaunchIntentForPackage(Context.PackageName);
-            return PendingIntent.GetActivity(Context, 0, sessionIntent, 0);
+
+            PendingIntentFlags flag = 0;
+            if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.M) flag = PendingIntentFlags.Immutable;
+
+            return PendingIntent.GetActivity(Context, 0, sessionIntent, flag);
         }
 
         public override Dictionary<string, string> RequestHeaders


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is a bug fix for make the plugin compatible with Android 12. It requires now FLAG_IMMUTABLE (or MUTABLE) for every PendingIntent.GetActivity(), otherwise, it fails to load the app.

### :arrow_heading_down: What is the current behavior?
The app crashes as soon as it starts, with the error
"Caused by: java.lang.IllegalArgumentException: fr.magina.radioperfecto: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent. Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles."

### :new: What is the new behavior (if this is a feature change)?
No more crash !


### :boom: Does this PR introduce a breaking change?
No, it's backward compatible

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#845 

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
