### PR TITLE
Fix: Set PlayerNotificationManager up correctly

### DIFF
--- a/MediaManager/Platforms/Android/MediaSession/MediaBrowserService.cs
+++ b/MediaManager/Platforms/Android/MediaSession/MediaBrowserService.cs
@@ -103,8 +103,10 @@ namespace MediaManager.Platforms.Android.MediaSession
             PlayerNotificationManager = new Com.Google.Android.Exoplayer2.UI.PlayerNotificationManager.Builder(
                 this,
                 ForegroundNotificationId,
-                ChannelId,
-                MediaDescriptionAdapter).Build();
+                ChannelId)
+                .SetMediaDescriptionAdapter(MediaDescriptionAdapter)
+                .SetNotificationListener(NotificationListener)
+                .Build();
 
             //Needed for enabling the notification as a mediabrowser.
             NotificationListener = new NotificationListener();
@@ -128,9 +130,6 @@ namespace MediaManager.Platforms.Android.MediaSession
 
             //PlayerNotificationManager.SetFastForwardIncrementMs((long)MediaManager.StepSizeForward.TotalMilliseconds);
             //PlayerNotificationManager.SetRewindIncrementMs((long)MediaManager.StepSizeBackward.TotalMilliseconds);
-
-            //TODO: not sure why this is broken? Maybe in the binding
-            //PlayerNotificationManager.SetNotificationListener(NotificationListener);
 
             PlayerNotificationManager.SetMediaSessionToken(SessionToken);
             //PlayerNotificationManager.SetOngoing(true);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Potential fix for https://github.com/Baseflow/XamarinMediaManager/issues/877 also sets up PlayerNotificationManager in the way Google intends it (Not deprecated)

### :arrow_heading_down: What is the current behavior?
Notification doesn't spawn correctly.

### :new: What is the new behavior (if this is a feature change)?
Notification should spawn correctly.

### :boom: Does this PR introduce a breaking change?
Haven't been able to test yet.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
