### PR TITLE
fixes issue #888, removing already removed observer causes app termination due to NSInvalidArgumentException

### DIFF
--- a/MediaManager/Platforms/Ios/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Ios/Player/AppleMediaPlayer.cs
@@ -228,6 +228,7 @@ namespace MediaManager.Platforms.Ios.Player
         {
             await Pause();
             Player.RemoveTimeObserver(playbackTimeObserver);
+            playbackTimeObserver = null;
         }
 
         public virtual async Task Play(AVPlayerItem playerItem)
@@ -276,7 +277,10 @@ namespace MediaManager.Platforms.Ios.Player
             });
 
             if (playbackTimeObserver != null)
+            {
                 Player.RemoveTimeObserver(playbackTimeObserver);
+                playbackTimeObserver = null;
+            }
 
             rateToken?.Dispose();
             statusToken?.Dispose();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce?
[fixes issue #888](https://github.com/Baseflow/XamarinMediaManager/issues/888)